### PR TITLE
Switch the default target from X86 to 'host'

### DIFF
--- a/cmake/caches/bootstrap-llvm-cache.cmake
+++ b/cmake/caches/bootstrap-llvm-cache.cmake
@@ -57,5 +57,5 @@ set_cache_variables(STRING
   VALUE OFF)
 
 set_cache(CLANG_DEFAULT_LINKER "lld")
-set_cache(LLVM_TARGETS_TO_BUILD "X86")
+set_cache(LLVM_TARGETS_TO_BUILD host)
 set_cache(LLVM_ENABLE_PROJECTS "clang;lld")


### PR DESCRIPTION
Use `host` instead of hard-coding X86 as the target to build. This way
the default behaviour will be to build the backend most relevant to the
host system.