### PR TITLE
Update Windows cross-builds for LLVM 15+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Exclude directories commonly created by the top-level build script.
-build/
-install/
-source/
-checkout/
-tools/
+build
+build_windows
+install
+install_windows
+source
+checkout
+tools
+windows
+
+update.sh

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ Clang, LLD, LLVM, and their associated runtimes will be installed to `./install/
 
 To build a Windows LLVM toolchain from your non-Windows build system, you must first have headers and libraries from [Visual Studio](https://visualstudio.microsoft.com/downloads/) and the [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/). You will need to copy the following directories to a location accessible by your build system:
 
-- Visual C++ base -- contains the C++ STL used by Visual Studio, usually found at `${env:ProgramFiles(x86)}\Microsoft Visual Studio\<vs-version>\Professional\VC\Tools\MSVC\<some-version-number>`. You'll only need the `include` and `lib` directories as well as the `atlmfc` directory if it exists.
-- Windows SDK base -- contains the native Windows headers and system libraries used by the Universal CRT, usually found at `${env:ProgramFiles(x86)}\Windows Kits\<windows-version>`. You'll only need the `Include` and `Lib` directories, and you can further streamline by only using a single version folder from each of these (such as `10.0.19041.0` for example). The rest of the version folders aren't required. You will, however, need to remember this version number as you will be using it to define the CMake variable `WINSDK_VER`.
+- Visual C++ base -- contains the C++ STL used by Visual Studio, usually found at `${env:ProgramFiles(x86)}\Microsoft Visual Studio\<vs-version>\Professional\VC\Tools\MSVC\<some-version-number>`. You'll only need the `include` and `lib` directories as well as the `atlmfc` directory if it exists. 
+- Windows SDK base -- contains the native Windows headers and system libraries used by the Universal CRT, usually found at `${env:ProgramFiles(x86)}\Windows Kits\<windows-version>`. You'll only need the `Include` and `Lib` directories, and you can further streamline by only using a single version folder from each of these (such as `10.0.19041.0` for example). The rest of the version folders aren't required.
 
 The build scripts make use of the [WinMsvc.cmake](https://github.com/llvm/llvm-project/blob/main/llvm/cmake/platforms/WinMsvc.cmake) toolchain script from the LLVM source in order to build for Windows. As such, some of the CMake variables used by this toolchain script also need to be specified when running `build-llvm-toolchain.cmake`:
 
-- `MSVC_BASE` -- absolute path to the directory containing the Visual C++ base files mentioned above
-- `WINSDK_BASE` -- absolute path to the directory containing the Windows SDK base files mentioned above
-- `WINSDK_VER` -- name of the version folder from the Windows SDK to use
+- `LLVM_WINSYSROOT` -- a directory containing both the Visual C++ base and the Windows SDK base. The following directories are expected to exist:
+  - `${LLVM_WINSYSROOT}/VC/Tools/MSVC/<msvc-version-number>`
+  - `${LLVM_WINSYSROOT}/Windows Kits/10/Include/<winsdk-version-number>`
+  - `${LLVM_WINSYSROOT}/Windows Kits/10/Lib/<winsdk-version-number>`
+- `MSVC_VER` (optional, defaults to highest found) -- name of the version folder of the Visual C++ base
+- `WINSDK_VER` (optional, defaults to highest found) -- name of the version folder from the Windows SDK to use
 - `HOST_ARCH` (optional, defaults to `x86_64`) -- host architecture for which to build (aarch64, arm64, armv7, arm, i686, x86, x86_64/x64)
 
 Finally, you must set `CMAKE_SYSTEM_NAME` to "Windows".
@@ -33,8 +36,6 @@ Finally, you must set `CMAKE_SYSTEM_NAME` to "Windows".
 git clone https://github.com/jvstech/llvm-toolchain.git .
 cmake \
   -DCMAKE_SYSTEM_NAME=Windows \
-  -DMSVC_BASE=/home/user/projects/msvc-base \
-  -DWINSDK_BASE=/home/user/projects/winsdk-base \
-  -DWINSDK_VER=10.0.19041.0 \
+  -DLLVM_WINSYSROOT=/home/user/projects/windows_sysroot \
   -P build-llvm-toolchain.cmake
 ```

--- a/cmake/caches/llvm-cache.cmake
+++ b/cmake/caches/llvm-cache.cmake
@@ -46,5 +46,9 @@ if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set_cache(CLANG_DEFAULT_UNWINDLIB "libunwind")
 else()
   set_cache(CMAKE_AR "${BOOTSTRAP_BUILD_DIR}/bin/llvm-lib" FILEPATH)
+  # FIXME: BLAKE3 can't yet be cross-compiled via assembler for Windows, apparently. So to work 
+  # around that, we set LLVM_DISABLE_ASSEMBLY_FILES which is (currently) only used by the BLAKE3
+  # CMakeLists.txt.
+  enable_cache_variables(LLVM_DISABLE_ASSEMBLY_FILES)
 endif()
 

--- a/projects/llvm/CMakeLists.txt
+++ b/projects/llvm/CMakeLists.txt
@@ -30,18 +30,22 @@ else()
   validate(
     HAS_VALUE
       HOST_ARCH
-      WINSDK_VER
     EXISTS
-      MSVC_BASE
-      WINSDK_BASE)
+      LLVM_WINSYSROOT)
   set(crossBuildArgs 
     -DCMAKE_SYSTEM_NAME=Windows 
     -DCMAKE_TOOLCHAIN_FILE=${LLVM_SOURCE_DIR}/cmake/platforms/WinMsvc.cmake 
     -DLLVM_NATIVE_TOOLCHAIN=${BOOTSTRAP_INSTALL_DIR} 
-    -DMSVC_BASE=${MSVC_BASE} 
-    -DWINSDK_BASE=${WINSDK_BASE} 
-    -DWINSDK_VER=${WINSDK_VER} 
+    -DLLVM_WINSYSROOT=${LLVM_WINSYSROOT} 
     -DHOST_ARCH=${HOST_ARCH})
+  if (MSVC_VER)
+    set(crossBuildArgs ${crossBuildArgs} 
+      -DMSVC_VER=${MSVC_VER})
+  endif()
+  if (WINSDK_VER)
+    set(crossBuildArgs ${crossBuildArgs} 
+      -DWINSDK_VER=${WINSDK_VER})
+  endif()
 endif()
 
 # Now configure and build the final version of Clang/LLVM.


### PR DESCRIPTION
This changes the expected layout of Windows include/library files and the CMake variables passed to LLVM in order to properly cross-build LLVM 15 and newer on Linux for Windows.

Closes #9