### PR TITLE
Update default LLVM version to 16.x

### DIFF
--- a/build-llvm-toolchain.cmake
+++ b/build-llvm-toolchain.cmake
@@ -5,7 +5,7 @@ macro(set_default varName value)
 endmacro()
 
 set_default(LLVM_PROJECT_REPO_URL "https://github.com/llvm/llvm-project")
-set_default(LLVM_VERSION "16.0.2")
+set_default(LLVM_VERSION "16.0.5")
 option(USE_LLVM_MAIN_BRANCH "Use the main branch of the LLVM source repo")
 option(UPDATE_SOURCE
   "Ensure the LLVM source is at the HEAD commit")

--- a/build-llvm-toolchain.cmake
+++ b/build-llvm-toolchain.cmake
@@ -5,7 +5,7 @@ macro(set_default varName value)
 endmacro()
 
 set_default(LLVM_PROJECT_REPO_URL "https://github.com/llvm/llvm-project")
-set_default(LLVM_VERSION "15.0.5")
+set_default(LLVM_VERSION "16.0.2")
 option(USE_LLVM_MAIN_BRANCH "Use the main branch of the LLVM source repo")
 option(UPDATE_SOURCE
   "Ensure the LLVM source is at the HEAD commit")


### PR DESCRIPTION
This sets the default LLVM version to clone to 16.0.2 -- not 16.0.0 as #14 indicates.